### PR TITLE
SAGE 007 Portfolio (User target/strategy/risk_tolerance Added)

### DIFF
--- a/backend/stocksage_api/routes/portfolio.py
+++ b/backend/stocksage_api/routes/portfolio.py
@@ -17,6 +17,8 @@ class PortfolioCreate(BaseModel):
     name: str
     start_date: datetime
     initial_balance: float
+    target_return: Optional[float] = None
+    strategy: Optional[str] = None
 
 class Holding(BaseModel):
     symbol: str
@@ -26,6 +28,11 @@ class Holding(BaseModel):
 class PortfolioResponse(PortfolioCreate):
     id: str
     holdings: Optional[Dict[str, Holding]] = None
+
+class PortfolioUpdate(BaseModel):
+    target_return: Optional[float] = None
+    strategy: Optional[str] = None
+
 
 class BuySellRequest(BaseModel):
     symbol: str
@@ -113,3 +120,17 @@ async def delete_portfolio(
         return {"message": "Portfolio deleted successfully"}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.patch("/{portfolio_id}", response_model=PortfolioResponse)
+async def update_portfolio(
+        portfolio_id: str,
+        update: PortfolioUpdate,
+        current_user: dict = Depends(get_current_user)
+):
+    try:
+        firebase_service.update_portfolio_strategy(current_user["uid"], portfolio_id, update.model_dump(exclude_unset=True))
+        return firebase_service.get_portfolio(current_user["uid"], portfolio_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+

--- a/backend/stocksage_api/routes/portfolio.py
+++ b/backend/stocksage_api/routes/portfolio.py
@@ -19,6 +19,7 @@ class PortfolioCreate(BaseModel):
     initial_balance: float
     target_return: Optional[float] = None
     strategy: Optional[str] = None
+    risk_tolerance: Optional[str] = None
 
 class Holding(BaseModel):
     symbol: str
@@ -32,6 +33,7 @@ class PortfolioResponse(PortfolioCreate):
 class PortfolioUpdate(BaseModel):
     target_return: Optional[float] = None
     strategy: Optional[str] = None
+    risk_tolerance: Optional[str] = None
 
 
 class BuySellRequest(BaseModel):

--- a/backend/stocksage_api/services/firebase_service.py
+++ b/backend/stocksage_api/services/firebase_service.py
@@ -291,9 +291,20 @@ class FirebaseService:
 
         data["id"] = portfolio_id
 
+        # Default values for target_return & strategy
+        data.setdefault("target_return", None)
+        data.setdefault("strategy", None)
+
         self.set_data(f"holdings/{user_id}/{portfolio_id}", {})
         self.set_data(f"portfolios/{user_id}/{portfolio_id}", data)
         return data
+
+    def update_portfolio_strategy(self, user_id: str, portfolio_id: str, updates: Dict[str, Any]):
+        allowed_fields = ["target_return", "strategy"]
+        filtered = {k: v for k, v in updates.items() if k in allowed_fields}
+        if filtered:
+            self.update_data(f"portfolios/{user_id}/{portfolio_id}", filtered)
+
 
     def get_transactions(self, user_id: str, portfolio_id: str) -> List[Dict[str, Any]]:
         txns = self.get_data(f"transactions/{user_id}/{portfolio_id}")

--- a/backend/stocksage_api/services/firebase_service.py
+++ b/backend/stocksage_api/services/firebase_service.py
@@ -294,13 +294,14 @@ class FirebaseService:
         # Default values for target_return & strategy
         data.setdefault("target_return", None)
         data.setdefault("strategy", None)
+        data.setdefault("risk_tolerance", None)
 
         self.set_data(f"holdings/{user_id}/{portfolio_id}", {})
         self.set_data(f"portfolios/{user_id}/{portfolio_id}", data)
         return data
 
     def update_portfolio_strategy(self, user_id: str, portfolio_id: str, updates: Dict[str, Any]):
-        allowed_fields = ["target_return", "strategy"]
+        allowed_fields = ["target_return", "strategy", "risk_tolerance"]
         filtered = {k: v for k, v in updates.items() if k in allowed_fields}
         if filtered:
             self.update_data(f"portfolios/{user_id}/{portfolio_id}", filtered)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 
 import PageLoader from '@/components/condtionalRender';
 import Link from "next/link";
+import api from "@/lib/api";
 
 export default function Home() {
     const router = useRouter();
@@ -65,8 +66,28 @@ export default function Home() {
 
 function RedirectToDashboard() {
     const router = useRouter();
+
     useEffect(() => {
-        router.push('/dashboard')
+        const redirect = async () => {
+            try {
+                const profile = await api.auth.getProfile();
+                const defaultView = profile.preferences?.default_view || "dashboard";
+
+                if (defaultView === "portfolio") {
+                    router.push("/portfolio");
+                } else {
+                    router.push("/dashboard");
+                }
+            } catch (e) {
+                console.error("Failed to get profile for redirect:", e);
+                router.push("/dashboard"); // fallback
+            }
+        };
+
+        redirect();
     }, [router]);
+
     return null;
 }
+
+

--- a/frontend/src/app/portfolio/[id]/page.tsx
+++ b/frontend/src/app/portfolio/[id]/page.tsx
@@ -234,7 +234,7 @@ export default function PortfolioDetailPage() {
 
             {/*target performance , strategy*/}
             <section className="border-t pt-4 space-y-4">
-                <h2 className="text-xl font-semibold">Portfolio Strategy & Target</h2>
+                <h2 className="text-xl font-semibold">Portfolio Strategy & Target & Risk_Tolerance </h2>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-1">
@@ -289,7 +289,7 @@ export default function PortfolioDetailPage() {
 
                 <div>
                     <Button onClick={handleUpdateDetails} disabled={isUpdating} className="w-full md:w-auto">
-                        {isUpdating ? "Updating..." : "Update Strategy & Target"}
+                        {isUpdating ? "Updating..." : "Update Your Choice"}
                     </Button>
                 </div>
             </section>

--- a/frontend/src/app/portfolio/[id]/page.tsx
+++ b/frontend/src/app/portfolio/[id]/page.tsx
@@ -187,6 +187,7 @@ export default function PortfolioDetailPage() {
                     ← Back to Portfolio List
                 </Button>
             </div>
+
             <section>
                 <h1 className="text-2xl font-bold">{portfolio.name}</h1>
                 <p className="text-muted-foreground text-sm">
@@ -327,6 +328,15 @@ export default function PortfolioDetailPage() {
                     <Button onClick={() => handleTrade("sell")} variant="destructive">Sell</Button>
                 </div>
                 {message && <p className="text-sm text-muted-foreground">{message}</p>}
+                <div className="pt-2">
+                    <Button
+                        variant="outline"
+                        className="w-full"
+                        onClick={() => router.push(`/portfolio/${id}/transactions`)}
+                    >
+                        See All Transactions
+                    </Button>
+                </div>
             </section>
         </main>
     )

--- a/frontend/src/app/portfolio/[id]/page.tsx
+++ b/frontend/src/app/portfolio/[id]/page.tsx
@@ -38,6 +38,8 @@ export default function PortfolioDetailPage() {
     const [targetReturn, setTargetReturn] = useState<string>("")
     const [strategy, setStrategy] = useState<string>("")
     const [isUpdating, setIsUpdating] = useState(false)
+    const [riskTolerance, setRiskTolerance] = useState<string>("");
+
 
 
 
@@ -55,6 +57,7 @@ export default function PortfolioDetailPage() {
                 setStocks(stockList)
                 setTargetReturn(data.target_return?.toString() || "")
                 setStrategy(data.strategy || "")
+                setRiskTolerance(data.risk_tolerance || "");
             } catch (error) {
                 console.error("Failed to fetch portfolio detail:", error)
             } finally {
@@ -72,6 +75,7 @@ export default function PortfolioDetailPage() {
             await api.portfolios.update(id, {
                 target_return: parseFloat(targetReturn),
                 strategy,
+                risk_tolerance: riskTolerance,
             })
 
             const updated = await api.portfolios.getOne(id)
@@ -265,6 +269,22 @@ export default function PortfolioDetailPage() {
                             </SelectContent>
                         </Select>
                     </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-muted-foreground" htmlFor="risk">
+                            Risk Tolerance
+                        </label>
+                        <Select value={riskTolerance} onValueChange={setRiskTolerance}>
+                            <SelectTrigger className="w-full" id="risk">
+                                <SelectValue placeholder="Select Risk Tolerance" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="Low">Low</SelectItem>
+                                <SelectItem value="Moderate">Moderate</SelectItem>
+                                <SelectItem value="High">High</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
                 </div>
 
                 <div>
@@ -290,6 +310,8 @@ export default function PortfolioDetailPage() {
                                     : "N/A"}
                             </p>
                             <p>Strategy: {portfolio?.strategy || "N/A"}</p>
+                            <p>Risk Tolerance: {portfolio?.risk_tolerance || "N/A"}</p>
+
                         </div>
                     </section>
                     <section className="border-t pt-4">

--- a/frontend/src/app/portfolio/[id]/transactions/page.tsx
+++ b/frontend/src/app/portfolio/[id]/transactions/page.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import { useEffect, useState } from "react"
-import { useParams } from "next/navigation"
+import { useParams, useRouter } from "next/navigation"
 import { api, Transaction } from "@/lib/api"
+import {Button} from "@/components/ui/button";
 
 export default function PortfolioTransactionsPage() {
     const { id } = useParams()
     const [transactions, setTransactions] = useState<Transaction[]>([])
     const [loading, setLoading] = useState(true)
+    const router = useRouter()
 
     useEffect(() => {
         const fetchTransactions = async () => {
@@ -31,6 +33,13 @@ export default function PortfolioTransactionsPage() {
 
     return (
         <main className="p-6 max-w-3xl mx-auto space-y-6">
+
+            <div className="flex justify-end">
+                <Button variant="outline" onClick={() => router.push(`/portfolio/${id}`)}>
+                    ← Back to Portfolio {id}
+                </Button>
+            </div>
+
             <h1 className="text-2xl font-bold mb-4">Transaction History</h1>
             <ul className="space-y-4">
                 {transactions.map((tx, index) => (

--- a/frontend/src/components/signIn-form.tsx
+++ b/frontend/src/components/signIn-form.tsx
@@ -1,20 +1,20 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+import {useState} from "react";
+import {useRouter} from "next/navigation";
+import {toast} from "sonner";
 import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Separator } from "@/components/ui/separator";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import {Button} from "@/components/ui/button";
+import {Input} from "@/components/ui/input";
+import {Label} from "@/components/ui/label";
+import {Checkbox} from "@/components/ui/checkbox";
+import {Separator} from "@/components/ui/separator";
+import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle} from "@/components/ui/card";
 
-import { auth } from "@/firebase/config";
-import { signInWithEmailAndPassword } from "firebase/auth";
-import { api } from "@/lib/api";
+import {auth} from "@/firebase/config";
+import {signInWithEmailAndPassword} from "firebase/auth";
+import {api} from "@/lib/api";
 
 export function LoginForm() {
     const [email, setEmail] = useState("");
@@ -27,29 +27,20 @@ export function LoginForm() {
         e.preventDefault();
         setIsLoading(true);
 
-        try { 
+        try {
             console.log("Attempting to sign in with Firebase...");
-            // First authenticate with Firebase
             await signInWithEmailAndPassword(auth, email, password);
             console.log("Firebase sign-in successful");
-            
-            // Wait for token to be available
-            try {             
-                console.log("Fetching user profile...");
-                // Fetch the user profile
-                await api.auth.getProfile();
-                console.log("Profile fetched successfully");
-                
-                router.push("/dashboard");
-            } catch (error) {
-                console.error("Backend verification error:", error);
-                toast.error("Failed to authenticate with backend. Please try again.");
-            } finally {
-                setIsLoading(false);
-            }
-            
+
+            console.log("Fetching user profile...");
+            const profile = await api.auth.getProfile();
+            console.log("Profile fetched successfully");
+
+            const defaultView = profile.preferences?.default_view || "dashboard";
+            router.push(defaultView === "portfolio" ? "/portfolio" : "/dashboard");
+
         } catch (error) {
-            console.error("Firebase auth error:", error);
+            console.error("Login error:", error);
             toast.error("Failed to sign in. Please check your credentials.");
         } finally {
             setIsLoading(false);
@@ -67,12 +58,14 @@ export function LoginForm() {
                     <form onSubmit={handleSubmit} className="space-y-4">
                         <div className="space-y-2">
                             <Label htmlFor="email">Email</Label>
-                            <Input id="email" type="email" placeholder="name@example.com" value={email} onChange={(e) => setEmail(e.target.value)} disabled={isLoading} required />
+                            <Input id="email" type="email" placeholder="name@example.com" value={email}
+                                   onChange={(e) => setEmail(e.target.value)} disabled={isLoading} required/>
                         </div>
 
                         <div className="space-y-2">
                             <Label htmlFor="password">Password</Label>
-                            <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} disabled={isLoading} required />
+                            <Input id="password" type="password" value={password}
+                                   onChange={(e) => setPassword(e.target.value)} disabled={isLoading} required/>
 
                             <div className="text-right">
                                 <Link href="/auth/reset" className="text-sm text-blue-600 hover:underline">
@@ -86,14 +79,11 @@ export function LoginForm() {
                         </Button>
 
                         {/* Sign Up Button */}
-                        <Button
-                            variant="outline"
-                            className="w-full mt-2"
-                            onClick={() => router.push("/signup")}
-                            disabled={isLoading}
-                        >
-                            Sign Up
-                        </Button>
+                        <Link href="/signup" className="block w-full">
+                            <Button variant="outline" className="w-full mt-2" disabled={isLoading}>
+                                Sign Up
+                            </Button>
+                        </Link>
                     </form>
                 </CardContent>
             </Card>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -79,6 +79,7 @@ export interface Portfolio {
   holdings?: { [symbol: string]: Holding };
   target_return?: number;
   strategy?: string;
+  risk_tolerance?: string;
 }
 
 export interface PortfolioUpdate {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,7 +77,15 @@ export interface Portfolio {
   start_date: string;
   initial_balance: number;
   holdings?: { [symbol: string]: Holding };
+  target_return?: number;
+  strategy?: string;
 }
+
+export interface PortfolioUpdate {
+  target_return?: number;
+  strategy?: string;
+}
+
 
 export interface Transaction {
   type: "buy" | "sell";
@@ -311,6 +319,13 @@ export const api = {
     delete: (portfolioId: string) =>
         fetchFromAPI<void>(`/api/portfolios/${portfolioId}`, {
           method: "DELETE",
+        }),
+
+    // update portfolio
+    update: (portfolioId: string, data: Partial<Portfolio>) =>
+        fetchFromAPI<Portfolio>(`/api/portfolios/${portfolioId}`, {
+          method: "PATCH",
+          body: JSON.stringify(data),
         }),
 
   },


### PR DESCRIPTION
Done:
- portfolio/{id}/transactions page
- user can select target return / strategy / risk_tolerance after creating a portfolio : can be used for AI recommendation
- user redirected to either /dashboard or /portfolio based on the preference


*further improvements:
- portfolio layout
- add daily/monthly performance report
- add sector allocation analysis
- add goal progress visualization(how close the portfolio is to hitting the target return)
- AI Strategy Recommendation, AI rebalancing suggestions etc.
